### PR TITLE
Add support for float values

### DIFF
--- a/python/src/argParser.py
+++ b/python/src/argParser.py
@@ -12,7 +12,7 @@ def createConfig(argv):
             elif opt in ['-F']:
                 cParams["dir"] = arg
             elif opt in ['-b']:
-                cParams["border"] = int(arg)
+                cParams["border"] = float(arg)
             elif opt in ['-c']:
                 cParams["colour"] = arg
             elif opt in ['-l']:

--- a/python/src/config.py
+++ b/python/src/config.py
@@ -2,7 +2,7 @@ class Config:
     def __init__(self, cParams: dict):
         self.filePath: str = cParams.get("file", None)
         self.dirPath: str = cParams.get("dir", None)
-        self.borderAmount: int = cParams.get("border", 5)
+        self.borderAmount: float = cParams.get("border", 5)
         self.colour: str = cParams.get("colour", "white")
         self.useLong: bool = cParams.get("useLong", False)
         

--- a/python/src/tests/test_config.py
+++ b/python/src/tests/test_config.py
@@ -34,6 +34,17 @@ class Test_createConfig(unittest.TestCase):
 
         self.assertEqual(parsedConf.borderAmount, 5)
 
+    def test_borderAmount_float(self):
+        conf = {"file": "test.jpg", "border": 10.5, "colour": "black", "useLong": True}
+        parsedConf = config.Config(conf)
+
+        self.assertEqual(parsedConf.borderAmount, 10.5)
+    
+    def test_borderAmount_floatUnderOne(self):
+        conf = {"file": "test.jpg", "border": 0.5, "colour": "black", "useLong": True}
+        parsedConf = config.Config(conf)
+
+        self.assertEqual(parsedConf.borderAmount, 0.5)
 
     def test_colour(self):
         conf = {"file": "test.jpg", "border": 10, "colour": "black", "useLong": True}


### PR DESCRIPTION
Allow for floating point values, for more specific border sizes, including those between 0-1%