### PR TITLE
Add extra detail to file naming

### DIFF
--- a/src/processor.py
+++ b/src/processor.py
@@ -9,9 +9,6 @@ import os
 def process(path, conf):
     osPath = os.path.abspath(path)
     print(f"Processing {osPath}")
-    # Separate filename from extension
-    fNameSplit = osPath.rsplit('.', 1)
-    newFilename = f"{fNameSplit[0]}_border.{fNameSplit[1]}"
 
     # Open the image and do the processing
     try:
@@ -24,9 +21,20 @@ def process(path, conf):
             if conf.resize != None:
                 toProcess.transform(resize=f'{conf.resize}x{conf.resize}')
 
-            toProcess.save(filename = newFilename)
+            toProcess.save(filename = generateNewFilePath(conf, osPath))
     except Exception as e:
         print(f"Couldn't process {osPath} - {e}")
+
+
+def generateNewFilePath(conf, originalPath) -> str:
+    # Separate filename from extension
+    fNameSplit = originalPath.rsplit('.', 1)
+
+    borderText = f"_{conf.borderAmount}pct{'l' if conf.useLong else 's'}-border" if conf.borderAmount != None else ""
+    ratioText = f"_{int(conf.ratio.split('x')[0])}x{int(conf.ratio.split('x')[1])}" if conf.ratio != None else ""
+    resizeText = f"_{conf.resize}px" if conf.resize != None else ""
+
+    return f"{fNameSplit[0]}{borderText}{ratioText}{resizeText}.{fNameSplit[1]}"
 
 
 def calculateBorderSize(conf, width, height):

--- a/src/tests/test_processor.py
+++ b/src/tests/test_processor.py
@@ -60,6 +60,40 @@ class Test_paddingCalculator(unittest.TestCase):
         c_1 = Config({"file": "test.jpg", "border": 10, "useLong": True, "ratio": "4x5"})
         self.assertEqual(processor.calculateBorderSize(c_1, 1000, 2000), (460,200)) # 2400x1920
 
+class Test_filepathGenerator(unittest.TestCase):
+    
+    orgFPath = "/usr/someone/images/test.jpg"
+
+    def setUp(self):
+        pass
+
+    def test_floatShortBorder(self):
+        c_1 = Config({"file": "test.jpg", "border": 0.5})
+        self.assertEqual(processor.generateNewFilePath(c_1, self.orgFPath), "/usr/someone/images/test_0.5pcts-border.jpg")
+
+    def test_floatLongBorder(self):
+        c_1 = Config({"file": "test.jpg", "border": 0.5, "useLong": True})
+        self.assertEqual(processor.generateNewFilePath(c_1, self.orgFPath), "/usr/someone/images/test_0.5pctl-border.jpg")
+
+    def test_IntShortBorder(self):
+        c_1 = Config({"file": "test.jpg", "border": 10})
+        self.assertEqual(processor.generateNewFilePath(c_1, self.orgFPath), "/usr/someone/images/test_10pcts-border.jpg")
+
+    def test_IntLongBorder(self):
+        c_1 = Config({"file": "test.jpg", "border": 10, "useLong": True})
+        self.assertEqual(processor.generateNewFilePath(c_1, self.orgFPath), "/usr/someone/images/test_10pctl-border.jpg")
+
+    def test_IntShortBorderRatio(self):
+        c_1 = Config({"file": "test.jpg", "border": 10, "ratio": "5x4"})
+        self.assertEqual(processor.generateNewFilePath(c_1, self.orgFPath), "/usr/someone/images/test_10pcts-border_5x4.jpg")
+
+    def test_IntShortBorderResize(self):
+        c_1 = Config({"file": "test.jpg", "border": 10, "resize": "2048"})
+        self.assertEqual(processor.generateNewFilePath(c_1, self.orgFPath), "/usr/someone/images/test_10pcts-border_2048px.jpg")
+
+    def test_IntShortBorderRatioResize(self):
+        c_1 = Config({"file": "test.jpg", "border": 10, "ratio": "5x4", "resize": "2048"})
+        self.assertEqual(processor.generateNewFilePath(c_1, self.orgFPath), "/usr/someone/images/test_10pcts-border_5x4_2048px.jpg")
 
 class Test_extensionParser(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
This prevents overwriting any other outputs when trying different combinations of properties